### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | Option<**String**> | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). | [optional]
+**id** | Option<**String**> | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly. | [optional]
 **external_id** | Option<**String**> | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`). | [optional]
 **errors** | Option<[**serde_json::Value**](.md)> | Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional]
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -170,6 +170,53 @@ async fn send_once(
     }
 }
 
+/// The branch of a POST /notifications 200 response where a notification was
+/// created (`id` is a non-empty string). Shares the
+/// [`models::CreateNotificationSuccessResponse`] shape; see
+/// [`models::CreateNotificationSuccessResponse::as_sent`].
+pub type MessageSent = models::CreateNotificationSuccessResponse;
+
+/// The branch of a POST /notifications 200 response where NO notification was
+/// created (`id` is absent or empty); `errors` carries the reason. Shares the
+/// [`models::CreateNotificationSuccessResponse`] shape; see
+/// [`models::CreateNotificationSuccessResponse::as_not_sent`].
+pub type MessageNotSent = models::CreateNotificationSuccessResponse;
+
+impl models::CreateNotificationSuccessResponse {
+    /// Whether this is the [`MessageSent`] branch — a notification was created
+    /// (`id` is present and non-empty). Prefer this over inspecting `id`
+    /// directly.
+    pub fn is_message_sent(&self) -> bool {
+        self.id.as_deref().map_or(false, |id| !id.is_empty())
+    }
+
+    /// Whether this is the [`MessageNotSent`] branch — no notification was
+    /// created (`id` absent or empty); inspect `errors` for why.
+    pub fn is_message_not_sent(&self) -> bool {
+        !self.is_message_sent()
+    }
+
+    /// Returns `Some(self)` viewed as a [`MessageSent`] when a notification was
+    /// created, otherwise `None`.
+    pub fn as_sent(&self) -> Option<&MessageSent> {
+        if self.is_message_sent() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `Some(self)` viewed as a [`MessageNotSent`] when no notification
+    /// was created, otherwise `None`.
+    pub fn as_not_sent(&self) -> Option<&MessageNotSent> {
+        if self.is_message_not_sent() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+}
+
 fn header_value(resp: &reqwest::Response, name: &str) -> Option<String> {
     resp.headers()
         .get(name)

--- a/src/models/create_notification_success_response.rs
+++ b/src/models/create_notification_success_response.rs
@@ -13,7 +13,7 @@
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct CreateNotificationSuccessResponse {
-    /// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).
+    /// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4438] fall back to code on null title in Rust error_messages
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...c73114f](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...c73114f026690637dccea57b21ee6f0a1eca5051)._