### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | Option<**String**> | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). | [optional]
+**id** | Option<**String**> | Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly. | [optional]
 **external_id** | Option<**String**> | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`). | [optional]
 **errors** | Option<[**serde_json::Value**](.md)> | Polymorphic field: may be an array of human-readable strings and/or an object (for example with `invalid_aliases`, `invalid_external_user_ids`, or `invalid_player_ids`) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional]
 

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -1768,7 +1768,7 @@ Name | Type | Description  | Required | Notes
 
 ## get_notifications
 
-> crate::models::NotificationSlice get_notifications(app_id, limit, offset, kind)
+> crate::models::NotificationSlice get_notifications(app_id, limit, offset, kind, time_offset)
 View notifications
 
 View the details of multiple notifications
@@ -1791,8 +1791,9 @@ async fn main() {
     let limit: Option<i32> = None;
     let offset: Option<i32> = None;
     let kind: Option<i32> = None;
+    let time_offset: Option<&str> = None;
 
-    match default_api::get_notifications(&configuration, app_id, limit, offset, kind).await {
+    match default_api::get_notifications(&configuration, app_id, limit, offset, kind, time_offset).await {
         Ok(resp) => println!("{:?}", resp),
         Err(e @ onesignal_rust_api::apis::Error::ResponseError(_)) => {
             // `e.error_messages()` flattens any error-envelope shape to a Vec<String>;
@@ -1813,6 +1814,7 @@ Name | Type | Description  | Required | Notes
 **limit** | Option<**i32**> | How many notifications to return.  Max is 50.  Default is 50. |  |
 **offset** | Option<**i32**> | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. |  |
 **kind** | Option<**i32**> | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  |  |
+**time_offset** | Option<**String**> | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned. |  |
 
 ### Return type
 

--- a/docs/NotificationSlice.md
+++ b/docs/NotificationSlice.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 **total_count** | Option<**i32**> |  | [optional]
 **offset** | Option<**i32**> |  | [optional]
 **limit** | Option<**i32**> |  | [optional]
+**time_offset** | Option<**String**> | The time_offset cursor specified in the request, if any. | [optional]
+**next_time_offset** | Option<**String**> | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. | [optional]
 **notifications** | Option<[**Vec<crate::models::NotificationWithMeta>**](NotificationWithMeta.md)> |  | [optional]
 
 [[Back to API list]](https://github.com/OneSignal/onesignal-rust-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-rust-api)

--- a/src/apis/default_api.rs
+++ b/src/apis/default_api.rs
@@ -1360,7 +1360,7 @@ pub async fn get_notification_history(configuration: &configuration::Configurati
 }
 
 /// View the details of multiple notifications
-pub async fn get_notifications(configuration: &configuration::Configuration, app_id: &str, limit: Option<i32>, offset: Option<i32>, kind: Option<i32>) -> Result<crate::models::NotificationSlice, Error<GetNotificationsError>> {
+pub async fn get_notifications(configuration: &configuration::Configuration, app_id: &str, limit: Option<i32>, offset: Option<i32>, kind: Option<i32>, time_offset: Option<&str>) -> Result<crate::models::NotificationSlice, Error<GetNotificationsError>> {
     let configuration = configuration;
 
     let client = &configuration.client;
@@ -1377,6 +1377,9 @@ pub async fn get_notifications(configuration: &configuration::Configuration, app
     }
     if let Some(ref str) = kind {
         req_builder = req_builder.query(&[("kind", &str.to_string())]);
+    }
+    if let Some(ref str) = time_offset {
+        req_builder = req_builder.query(&[("time_offset", &str.to_string())]);
     }
     if let Some(ref user_agent) = configuration.user_agent {
         req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -170,6 +170,53 @@ async fn send_once(
     }
 }
 
+/// The branch of a POST /notifications 200 response where a notification was
+/// created (`id` is a non-empty string). Shares the
+/// [`models::CreateNotificationSuccessResponse`] shape; see
+/// [`models::CreateNotificationSuccessResponse::as_sent`].
+pub type MessageSent = models::CreateNotificationSuccessResponse;
+
+/// The branch of a POST /notifications 200 response where NO notification was
+/// created (`id` is absent or empty); `errors` carries the reason. Shares the
+/// [`models::CreateNotificationSuccessResponse`] shape; see
+/// [`models::CreateNotificationSuccessResponse::as_not_sent`].
+pub type MessageNotSent = models::CreateNotificationSuccessResponse;
+
+impl models::CreateNotificationSuccessResponse {
+    /// Whether this is the [`MessageSent`] branch — a notification was created
+    /// (`id` is present and non-empty). Prefer this over inspecting `id`
+    /// directly.
+    pub fn is_message_sent(&self) -> bool {
+        self.id.as_deref().map_or(false, |id| !id.is_empty())
+    }
+
+    /// Whether this is the [`MessageNotSent`] branch — no notification was
+    /// created (`id` absent or empty); inspect `errors` for why.
+    pub fn is_message_not_sent(&self) -> bool {
+        !self.is_message_sent()
+    }
+
+    /// Returns `Some(self)` viewed as a [`MessageSent`] when a notification was
+    /// created, otherwise `None`.
+    pub fn as_sent(&self) -> Option<&MessageSent> {
+        if self.is_message_sent() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `Some(self)` viewed as a [`MessageNotSent`] when no notification
+    /// was created, otherwise `None`.
+    pub fn as_not_sent(&self) -> Option<&MessageNotSent> {
+        if self.is_message_not_sent() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+}
+
 fn header_value(resp: &reqwest::Response, name: &str) -> Option<String> {
     resp.headers()
         .get(name)

--- a/src/models/create_notification_success_response.rs
+++ b/src/models/create_notification_success_response.rs
@@ -13,7 +13,7 @@
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct CreateNotificationSuccessResponse {
-    /// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).
+    /// Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).

--- a/src/models/notification_slice.rs
+++ b/src/models/notification_slice.rs
@@ -19,6 +19,12 @@ pub struct NotificationSlice {
     pub offset: Option<i32>,
     #[serde(rename = "limit", skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,
+    /// The time_offset cursor specified in the request, if any.
+    #[serde(rename = "time_offset", skip_serializing_if = "Option::is_none")]
+    pub time_offset: Option<String>,
+    /// An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.
+    #[serde(rename = "next_time_offset", skip_serializing_if = "Option::is_none")]
+    pub next_time_offset: Option<String>,
     #[serde(rename = "notifications", skip_serializing_if = "Option::is_none")]
     pub notifications: Option<Vec<crate::models::NotificationWithMeta>>,
 }
@@ -29,6 +35,8 @@ impl NotificationSlice {
             total_count: None,
             offset: None,
             limit: None,
+            time_offset: None,
+            next_time_offset: None,
             notifications: None,
         }
     }


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4438] fall back to code on null title in Rust error_messages
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...2907ac8](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...2907ac87ca594fc5aee71ccfab5839f35b6a0f38)._